### PR TITLE
Fix HTML loading and modernize button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,6 @@
     </aside>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
-  <script type="module" src="main.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,32 @@ body {
   line-height: 1.4;
 }
 
+button,
+input,
+select {
+  font-family: inherit;
+}
+
+button {
+  appearance: none;
+  border: 1px solid #a5a5a5;
+  border-radius: 6px;
+  background: linear-gradient(#ffffff, #e6e6e6);
+  color: #333;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+button:hover {
+  background: linear-gradient(#f5f5f5, #dcdcdc);
+}
+
+button:active {
+  background: linear-gradient(#dcdcdc, #f5f5f5);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.2);
+}
+
 .top-bar {
   display: flex;
   align-items: center;
@@ -27,6 +53,13 @@ body {
 
 .top-bar button {
   margin-left: 0.5rem;
+  background: linear-gradient(#555, #333);
+  border-color: #222;
+  color: #fff;
+}
+
+.top-bar button:hover {
+  background: linear-gradient(#666, #444);
 }
 
 .layout {
@@ -72,9 +105,70 @@ body {
   margin: 0.5rem 0 0.2rem;
 }
 
-button:focus, input:focus, select:focus {
-  outline: 2px solid #0078d4;
-  outline-offset: 2px;
+input,
+select {
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  padding: 0.25rem;
+  transition: border 0.2s, box-shadow 0.2s;
+}
+
+input:hover,
+select:hover {
+  border-color: #999;
+}
+
+button:focus,
+input:focus,
+select:focus {
+  border-color: #0078d4;
+  box-shadow: 0 0 3px rgba(0,120,212,0.5);
+  outline: none;
+}
+
+/* Sidebar buttons */
+.panel-btn {
+  width: 100%;
+  text-align: left;
+  margin: 0.25rem 0;
+}
+
+/* Range slider styling */
+input[type=range] {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: #ccc;
+}
+
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid #aaa;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  transition: background 0.2s;
+}
+
+input[type=range]:hover::-webkit-slider-thumb {
+  background: #f0f0f0;
+}
+
+input[type=range]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid #aaa;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  transition: background 0.2s;
+}
+
+input[type=range]:hover::-moz-range-thumb {
+  background: #f0f0f0;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Remove `type="module"` so `main.js` runs when opening `index.html` directly
- Restyle buttons, inputs and sliders for a macOS-inspired look while keeping existing colors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a09491ea30832f8916dc3506a334fb